### PR TITLE
Fix eBCSgen simulation: replace hidden attribute by conditions

### DIFF
--- a/tools/ebcsgen/ebcsgen_simulate.xml
+++ b/tools/ebcsgen/ebcsgen_simulate.xml
@@ -12,11 +12,18 @@
         --model '$model'
         --output '$output'
         --deterministic '$type.deterministic_choice'
-        --direct '$type.network_free_choice'
-        --runs '$type.num_of_runs'
+        #if $type.deterministic_choice == "True":
+            --direct False
+            --runs 1
+            --volume '$type.volume'
+            --step '$type.step'
+        #else:
+            --direct '$type.network_free_choice'
+            --runs '$type.num_of_runs'
+            --volume 1
+            --step 0.01
+        #end if
         --max_time '$max_time'
-        --volume '$type.volume'
-        --step '$type.step'
     </command>
 
     <inputs>
@@ -32,15 +39,8 @@
                     <option value="True">Direct</option>
                 </param>
                 <param name="num_of_runs" min="1" type="integer" value="1" label="Number of runs:"/>
-                <param name="volume" min="0" type="integer" value="1" hidden="true"/>
-                <param name="step" min="0" type="float" value="0.01" hidden="true"/>
             </when>
             <when value="True">
-                <param name="network_free_choice" type="select" label="Choose network-free approach:" hidden="true">
-                    <option value="False" selected="true">Indirect</option>
-                    <option value="True">Direct</option>
-                </param>
-                <param name="num_of_runs" min="1" type="integer" value="1" hidden="true"/>
                 <param name="volume" min="0" type="integer" value="1" label="Volume (liters):"/>
                 <param name="step" min="0" type="float" value="0.01" label="Simulation step:"/>
             </when>
@@ -57,8 +57,6 @@
             <param name="model" value="repressilator.bcsl.model" ftype="bcsl.model"/>
             <section name="type">
                 <param name="deterministic_choice" value="True"/>
-                <param name="network_free_choice" value="False"/>
-                <param name="num_of_runs" value="1"/>
                 <param name="step" value="0.1"/>
             </section>
             <param name="max_time" value="100"/>
@@ -70,7 +68,6 @@
                 <param name="deterministic_choice" value="False"/>
                 <param name="network_free_choice" value="False"/>
                 <param name="num_of_runs" value="2"/>
-                <param name="step" value="0.1"/>
             </section>
             <param name="max_time" value="200"/>
             <output name="output" ftype="csv">
@@ -86,7 +83,6 @@
                 <param name="deterministic_choice" value="False"/>
                 <param name="network_free_choice" value="True"/>
                 <param name="num_of_runs" value="1"/>
-                <param name="step" value="0.1"/>
             </section>
             <param name="max_time" value="100"/>
             <output name="output" ftype="csv">


### PR DESCRIPTION
Assigning `hidden` to a `param` is not allowed. This PR replaces their usage by conditions in command construction.